### PR TITLE
Initialize extraction result control and clear parameter buffer

### DIFF
--- a/SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/test/linux/firm_update/firm_update.c
+++ b/SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/test/linux/firm_update/firm_update.c
@@ -1115,6 +1115,9 @@ int param_extract(char *ifname, uint16 slave)
                 fclose(fp);
         }
 
+        /* 기존 파라미터 정보는 재사용되지 않으므로 메모리를 정리한다. */
+        memset(&Param_Raw, 0, sizeof(Param_Raw));
+
         return iResult;
 }
 

--- a/SourceCode_ver_2.0.1/Source_20/11.GUI_Step_20_OHT_v8_2/update_ui/GUIFrame.cpp
+++ b/SourceCode_ver_2.0.1/Source_20/11.GUI_Step_20_OHT_v8_2/update_ui/GUIFrame.cpp
@@ -50,6 +50,12 @@ GUIFrame::GUIFrame( wxWindow* parent, wxWindowID id, const wxString& title, cons
     m_button_param_extraction = new wxButton(this, wxID_BUTTON_PARAM_EXTRACTION, wxT("Extraction"), wxDefaultPosition, wxDefaultSize, 0);
     horizontalSizer->Add(m_button_param_extraction, 0, wxALIGN_CENTER_VERTICAL);
 
+    // 결과 표시를 위한 텍스트 박스 추가
+    m_text_result_param = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+                                        wxDefaultPosition, wxDefaultSize,
+                                        wxTE_READONLY);
+    horizontalSizer->Add(m_text_result_param, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 5);
+
     topSizer->Add(horizontalSizer, 0, wxEXPAND | wxALL, 5);
 
 	wxBoxSizer* bSizer1;


### PR DESCRIPTION
## Summary
- Create `m_text_result_param` in GUIFrame constructor so extraction button updates a valid text field
- Reset parameter buffer after extraction to free unused data

## Testing
- `gcc -c SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/test/linux/firm_update/firm_update.c -I SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/soem -I SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/osal -I SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/osal/linux -I SourceCode_ver_2.0.1/Source_20/01.SOEM_20/SOEM-master/oshw/linux`


------
https://chatgpt.com/codex/tasks/task_e_68a5931a0ddc832294a235386b9a624a